### PR TITLE
Give priority over EssentialsX

### DIFF
--- a/src/main/java/me/hsgamer/bettereconomy/BetterEconomy.java
+++ b/src/main/java/me/hsgamer/bettereconomy/BetterEconomy.java
@@ -25,6 +25,7 @@ import me.lokka30.treasury.api.common.service.ServiceRegistry;
 import me.lokka30.treasury.api.economy.EconomyProvider;
 import net.milkbowl.vault.economy.Economy;
 import org.bstats.bukkit.Metrics;
+import org.bukkit.plugin.ServicePriority;
 
 @Getter
 public final class BetterEconomy extends BasePlugin {
@@ -41,7 +42,7 @@ public final class BetterEconomy extends BasePlugin {
 
         if (mainConfig.isHookEnabled()) {
             if (getServer().getPluginManager().getPlugin("Vault") != null) {
-                registerProvider(Economy.class, new VaultEconomyHook(this));
+                registerProvider(Economy.class, new VaultEconomyHook(this), ServicePriority.High);
             } else if (getServer().getPluginManager().getPlugin("Treasury") != null) {
                 ServiceRegistry.INSTANCE.registerService(
                         EconomyProvider.class,


### PR DESCRIPTION
Vault doesn't prioritize BetterEconomy when EssentialsX is installed due to both having the same ServicePriority. This fixes the issue and makes BetterEconomy the main economy for Vault.